### PR TITLE
Fix polluted logger

### DIFF
--- a/reporter.go
+++ b/reporter.go
@@ -1,10 +1,7 @@
 package nrgorm
 
 import (
-	"fmt"
-
 	"github.com/jinzhu/gorm"
-	"github.com/newrelic/go-agent"
 )
 
 type reporter interface {
@@ -46,6 +43,4 @@ func (r *repoImpl) Report(startTime *newrelic.SegmentStartTime, tableName string
 		DatabaseName:       r.dbName,
 	}
 	err := seg.End()
-	fmt.Println((*startTime))
-	fmt.Println(err)
 }


### PR DESCRIPTION
These 2 lines of `fmt.Println()` make our logger polluted as below.
```
{{{0 0} <nil>}}
<nil>
```
If it is able to drop these lines, I want to get this merged. 

And my `goimports` removes the `"github.com/newrelic/go-agent"` import because of needless.